### PR TITLE
Early Homebrew formula for installing super

### DIFF
--- a/super.rb
+++ b/super.rb
@@ -1,0 +1,17 @@
+class Super < Formula
+  desc "Query and search data in files or SuperDB data lakes"
+  homepage "https://superdb.org"
+  url "https://github.com/brimdata/super/archive/727a84d.zip"
+  sha256 "c56255af9871e5752f78d06b037ce72b51ae14e520f0ff0e2c8f020b0e48e471"
+  version "727a84d"
+
+  depends_on "go@1.23" => :build
+
+  def install
+    ENV["GOPATH"] = buildpath
+    (buildpath/"build/src").mkpath
+    ln_s buildpath, buildpath/"build/src/github.com"
+    system "GOPATH=$PWD/build go install github.com/brimdata/super/cmd/super@727a84d"
+    bin.install "build/bin/super"
+  end
+end


### PR DESCRIPTION
## What's Changing

This formula will allow users to get a working `super` binary on macOS and Linux by running:

```
brew install brimdata/tap/super
```

## Why

We want to get an early version of the SuperDB site up ASAP at https://superdb.org and show a working Homebrew command line as part of that.

## Details

This is effectively not much more sophisticated than the [Building from source](https://zed.brimdata.io/docs/next/install#building-from-source) instructions we've always shown in the Zed docs (i.e., `go install`), but it leverages Homebrew's ability to grab dependencies (i.e., Go will be installed for compilation if it's not already present.)

The [GoReleaser Homebrew config in the super repo](https://github.com/brimdata/super/blob/main/.goreleaser.yaml) will replace this formula when we do an official GA release of super. However, a GA release is not expected until we've got all the pieces lined up (e.g., a first cut at working SuperSQL, updated docs in a tag-worthy state, etc.) so right now I've got the formula rigged up to point to a specific point-in-time commit of the super repo. We can update that commit periodically as we march toward GA and hit milestones that feel worthy of treating like pre-releases.

I based this formula on [this simple one for `ls-go`](https://github.com/acarl005/homebrew-formulas/blob/master/Formula/ls-go.rb) that I found via web search as an example of compiling a Go CLI tool from source. I intentionally started with the bare minimum since I don't have confidence in my Go dev abilities to get fancy. Enhancements are welcomed, but this should all be fairly temporary.

## Testing

If you want to experience this as a user, I have this same formula in a personal repo, so you can do:

```
brew install philrz/tap/super
```

That'll put the binary in `/usr/local/bin/super`. If you want to put everything back the way it was afterwards, do:

```
brew uninstall super
brew untap philrz/homebrew-tap
```

To test on "scratch hosts" other than my own laptop, I used [ngrok-ssh](https://github.com/philrz/ngrok-ssh) to install it on all the following GitHub Actions Runner types:

* `macos-12`
* `macos-13`
* `macos-14`
* `macos-15`
* `ubuntu-20.04`
* `ubuntu-22.04`
* `ubuntu-24.04`

The Linux runners don't have Homebrew installed by default so I ran the one-liner [Homebrew install](https://brew.sh/) on those first, but other than that, the install proceeded similarly on all of them. On some of the runners it did indeed end up installing Go 1.23 and on some of the Linux ones it even had to get other basic build stuff like `gcc` but thankfully in the end on all of them it did produce a working `super` binary. Here's an example session output on `macos-13`:

```
Mac-1729796896463:~ runner$ brew install philrz/tap/super
==> Tapping philrz/tap
Cloning into '/usr/local/Homebrew/Library/Taps/philrz/homebrew-tap'...
remote: Enumerating objects: 25, done.
remote: Counting objects: 100% (25/25), done.
remote: Compressing objects: 100% (18/18), done.
remote: Total 25 (delta 13), reused 15 (delta 6), pack-reused 0 (from 0)
Receiving objects: 100% (25/25), done.
Resolving deltas: 100% (13/13), done.
Tapped 1 formula (15 files, 10.6KB).
==> Fetching dependencies for philrz/tap/super: go
==> Fetching go
==> Downloading https://ghcr.io/v2/homebrew/core/go/manifests/1.23.2
######################################################################### 100.0%
==> Downloading https://ghcr.io/v2/homebrew/core/go/blobs/sha256:57c7e66ca7ea40c
######################################################################### 100.0%
==> Fetching philrz/tap/super
==> Downloading https://github.com/brimdata/super/archive/727a84d.zip
==> Downloading from https://codeload.github.com/brimdata/super/zip/727a84de8df0
 # #-=#=- #                                                                     
==> Installing super from philrz/tap
Warning: A newer Command Line Tools release is available.
Update them from Software Update in System Settings.

If that doesn't show you any updates, run:
  sudo rm -rf /Library/Developer/CommandLineTools
  sudo xcode-select --install

Alternatively, manually download them from:
  https://developer.apple.com/download/all/.
You should download the Command Line Tools for Xcode 15.2.

==> Installing dependencies for philrz/tap/super: go
==> Installing philrz/tap/super dependency: go
==> Downloading https://ghcr.io/v2/homebrew/core/go/manifests/1.23.2
Already downloaded: /Users/runner/Library/Caches/Homebrew/downloads/04bfd4233f1d73207e431c34fce72bd3d9d830970f7285e0839f8b0969f37bb8--go-1.23.2.bottle_manifest.json
==> Pouring go--1.23.2.ventura.bottle.tar.gz
🍺  /usr/local/Cellar/go/1.23.2: 13,234 files, 272.2MB
==> Installing philrz/tap/super
==> GOPATH=$PWD/build go install github.com/brimdata/super/cmd/super@727a84d
🍺  /usr/local/Cellar/super/727a84d: 7 files, 64.9MB, built in 1 minute 57 seconds
Mac-1729796896463:~ runner$ super -version
Version: v1.18.1-0.20241024165653-727a84de8df0
Mac-1729796896463:~ runner$ echo 2 | super -c 'yield this+2' -
```
