### PR TITLE
Build from super commit 55d99d3

### DIFF
--- a/super.rb
+++ b/super.rb
@@ -1,9 +1,9 @@
 class Super < Formula
   desc "Query and search data in files or SuperDB data lakes"
   homepage "https://superdb.org"
-  url "https://github.com/brimdata/super/archive/727a84d.zip"
-  sha256 "c56255af9871e5752f78d06b037ce72b51ae14e520f0ff0e2c8f020b0e48e471"
-  version "727a84d"
+  url "https://github.com/brimdata/super/archive/55d99d3.zip"
+  sha256 "e286e4c49f1b3069ae2112395f1165863c806afcb51087d7ae2f162b063ab48e"
+  version "55d99d3"
 
   depends_on "go@1.23" => :build
 
@@ -11,7 +11,7 @@ class Super < Formula
     ENV["GOPATH"] = buildpath
     (buildpath/"build/src").mkpath
     ln_s buildpath, buildpath/"build/src/github.com"
-    system "GOPATH=$PWD/build go install github.com/brimdata/super/cmd/super@727a84d"
+    system "GOPATH=$PWD/build go install github.com/brimdata/super/cmd/super@55d99d3"
     bin.install "build/bin/super"
   end
 end


### PR DESCRIPTION
I got the first version of this formula working back in October when we wanted an early version of SuperDB to be easily installable even before we have a proper release. I was recently advising a community user that they could take advantage of the new https://github.com/brimdata/super/pull/5570 `-f line` functionality if they're willing to run tip-of-`main` SuperDB, which led me to confront the desirability of having Homebrew build from a current commit.