### PR TITLE
Update Homebrew formulae

### DIFF
--- a/super.rb
+++ b/super.rb
@@ -1,9 +1,9 @@
 class Super < Formula
   desc "Query and search data in files or SuperDB data lakes"
   homepage "https://superdb.org"
-  url "https://github.com/brimdata/super/archive/da56639.zip"
-  sha256 "b44eae9937fef284a3a1cb943a450c8acd702328bfdb99431abf59978b63f367"
-  version "da56639"
+  url "https://github.com/brimdata/super/archive/0cb66f4.zip"
+  sha256 "24d7afc4a430744fd65f01a89b01553bb5d895d990771199fa9b4e415ab66edb"
+  version "0cb66f4"
 
   depends_on "go@1.24" => :build
 
@@ -11,7 +11,7 @@ class Super < Formula
     ENV["GOPATH"] = buildpath
     (buildpath/"build/src").mkpath
     ln_s buildpath, buildpath/"build/src/github.com"
-    system "GOPATH=$PWD/build go install github.com/brimdata/super/cmd/super@da56639"
+    system "GOPATH=$PWD/build go install github.com/brimdata/super/cmd/super@0cb66f4"
     bin.install "build/bin/super"
   end
 end

--- a/zed.rb
+++ b/zed.rb
@@ -6,12 +6,12 @@ class Zed < Formula
   desc "A command-line tool for creating, configuring, ingesting into, querying,
 and orchestrating Zed data lakes.
 "
-  homepage "https://github.com/brimdata/zed"
+  homepage "https://github.com/brimdata/zed-archive"
   version "1.18.0"
 
   on_macos do
     on_intel do
-      url "https://github.com/brimdata/zed/releases/download/v1.18.0/zed-v1.18.0.darwin-amd64.tar.gz"
+      url "https://github.com/brimdata/zed-archive/releases/download/v1.18.0/zed-v1.18.0.darwin-amd64.tar.gz"
       sha256 "3cfb3c37edf0793ca75a47df73f4be77ce6e534bfe7d103283b9391c279df2cd"
 
       def install
@@ -19,7 +19,7 @@ and orchestrating Zed data lakes.
       end
     end
     on_arm do
-      url "https://github.com/brimdata/zed/releases/download/v1.18.0/zed-v1.18.0.darwin-arm64.tar.gz"
+      url "https://github.com/brimdata/zed-archive/releases/download/v1.18.0/zed-v1.18.0.darwin-arm64.tar.gz"
       sha256 "b7af92d873f6486b2dab852093e0a94b4250dead5cf072dede098acbe1765b14"
 
       def install
@@ -31,7 +31,7 @@ and orchestrating Zed data lakes.
   on_linux do
     on_intel do
       if Hardware::CPU.is_64_bit?
-        url "https://github.com/brimdata/zed/releases/download/v1.18.0/zed-v1.18.0.linux-amd64.tar.gz"
+        url "https://github.com/brimdata/zed-archive/releases/download/v1.18.0/zed-v1.18.0.linux-amd64.tar.gz"
         sha256 "3f9c61d28e08aaff03cbeaadceb08da36296055b835182d1a6c50c401271060f"
 
         def install
@@ -41,7 +41,7 @@ and orchestrating Zed data lakes.
     end
     on_arm do
       if Hardware::CPU.is_64_bit?
-        url "https://github.com/brimdata/zed/releases/download/v1.18.0/zed-v1.18.0.linux-arm64.tar.gz"
+        url "https://github.com/brimdata/zed-archive/releases/download/v1.18.0/zed-v1.18.0.linux-arm64.tar.gz"
         sha256 "dfa109865e2d5d7c2b6c6b36b2b763bd3e2e34f74ea6cbcf7fc18c266a48f88a"
 
         def install

--- a/zq.rb
+++ b/zq.rb
@@ -7,12 +7,12 @@ class Zq < Formula
 providing search, analytics, and extensive transormations using the Zed
 query language.
 "
-  homepage "https://github.com/brimdata/zed"
+  homepage "https://github.com/brimdata/zed-archive"
   version "1.18.0"
 
   on_macos do
     on_intel do
-      url "https://github.com/brimdata/zed/releases/download/v1.18.0/zed-v1.18.0.darwin-amd64.tar.gz"
+      url "https://github.com/brimdata/zed-archive/releases/download/v1.18.0/zed-v1.18.0.darwin-amd64.tar.gz"
       sha256 "3cfb3c37edf0793ca75a47df73f4be77ce6e534bfe7d103283b9391c279df2cd"
 
       def install
@@ -20,7 +20,7 @@ query language.
       end
     end
     on_arm do
-      url "https://github.com/brimdata/zed/releases/download/v1.18.0/zed-v1.18.0.darwin-arm64.tar.gz"
+      url "https://github.com/brimdata/zed-archive/releases/download/v1.18.0/zed-v1.18.0.darwin-arm64.tar.gz"
       sha256 "b7af92d873f6486b2dab852093e0a94b4250dead5cf072dede098acbe1765b14"
 
       def install
@@ -32,7 +32,7 @@ query language.
   on_linux do
     on_intel do
       if Hardware::CPU.is_64_bit?
-        url "https://github.com/brimdata/zed/releases/download/v1.18.0/zed-v1.18.0.linux-amd64.tar.gz"
+        url "https://github.com/brimdata/zed-archive/releases/download/v1.18.0/zed-v1.18.0.linux-amd64.tar.gz"
         sha256 "3f9c61d28e08aaff03cbeaadceb08da36296055b835182d1a6c50c401271060f"
 
         def install
@@ -42,7 +42,7 @@ query language.
     end
     on_arm do
       if Hardware::CPU.is_64_bit?
-        url "https://github.com/brimdata/zed/releases/download/v1.18.0/zed-v1.18.0.linux-arm64.tar.gz"
+        url "https://github.com/brimdata/zed-archive/releases/download/v1.18.0/zed-v1.18.0.linux-arm64.tar.gz"
         sha256 "dfa109865e2d5d7c2b6c6b36b2b763bd3e2e34f74ea6cbcf7fc18c266a48f88a"
 
         def install


### PR DESCRIPTION
While fielding a question from a user on community Slack, I became aware that the Homebrew formulae for the old Zed-era tools no longer work. Here I'm updating them to point to their new locations at the zed-archive repo.

While I'm at it, I can see it's been a while since we've updated the pre-release formula for SuperDB, so I'm taking care of that as well.