### PR TITLE
Distrbute prerelease super via Homebrew Cask

### DIFF
--- a/.github/workflows/homebrew-update.yaml
+++ b/.github/workflows/homebrew-update.yaml
@@ -41,7 +41,7 @@ jobs:
       - name: Upload artifacts to S3 bucket
         if: steps.changed.outputs.changed == 'true'
         run: |
-          short_hash=$(git -C super rev-parse --short HEAD)
+          short_hash=$(git -C super rev-parse --short=7 HEAD)
           for artifact in super/dist/super-${short_hash}*; do aws s3 cp $artifact s3://super-prereleases/${short_hash}/ ; done
       - name: Save updated Cask to Homebrew tap repo
         if: steps.changed.outputs.changed == 'true'
@@ -51,5 +51,5 @@ jobs:
           git config --global user.name 'Brim Automation'
           git config --global user.email 'automation@brimdata.com'
           git add Casks/super.rb
-          git commit -am "update super Homebrew Cask to $(git -C super rev-parse --short HEAD)" || true
+          git commit -am "update super Homebrew Cask to $(git -C super rev-parse --short=7 HEAD)" || true
           git push

--- a/.github/workflows/homebrew-update.yaml
+++ b/.github/workflows/homebrew-update.yaml
@@ -10,11 +10,11 @@ jobs:
     runs-on: ubuntu-22.04
     steps:
       - name: Checkout homebrew-tap
-        uses: actions/checkout@v4
+        uses: actions/checkout@v5
         with:
           token: ${{ secrets.PAT_TOKEN }}
       - name: Checkout super
-        uses: actions/checkout@v4
+        uses: actions/checkout@v5
         with:
           repository: brimdata/super
           path: super

--- a/.github/workflows/homebrew-update.yaml
+++ b/.github/workflows/homebrew-update.yaml
@@ -21,7 +21,7 @@ jobs:
       - name: Check if super main has changed
         id: changed
         run: |
-          ( [ ! -f Casks/super.rb ] || [ $(awk '/version/ {print $2}' Casks/super.rb | head -1 | tr -d '"') != $(git -C super rev-parse --short HEAD | cut -c1-7) ] ) && echo "changed=true" >> $GITHUB_OUTPUT || true
+          ( [ ! -f Casks/super.rb ] || [ $(awk '/version/ {print $2}' Casks/super.rb | head -1 | tr -d '"') != $(git -C super rev-parse --short=7 HEAD) ] ) && echo "changed=true" >> $GITHUB_OUTPUT || true
       - uses: actions/setup-go@v5
         with:
           go-version-file: super/go.mod

--- a/.github/workflows/homebrew-update.yaml
+++ b/.github/workflows/homebrew-update.yaml
@@ -13,40 +13,15 @@ jobs:
         uses: actions/checkout@v4
         with:
           token: ${{ secrets.PAT_TOKEN }}
-          fetch-depth: 0    
       - name: Checkout super
         uses: actions/checkout@v4
         with:
           repository: brimdata/super
-          fetch-depth: 0
           path: super
-      - name: Get current super main commit SHA
-        id: current
-        run: |
-          cd super
-          CURRENT_SHA=$(git rev-parse origin/main)
-          echo "sha=$CURRENT_SHA" >> $GITHUB_OUTPUT
-      - name: Restore previous commit SHA
-        id: cache
-        uses: actions/cache/restore@v4
-        with:
-          path: .commit-sha
-          key: main-commit-${{ steps.current.outputs.sha }}
-          restore-keys: |
-            main-commit-
       - name: Check if super main has changed
         id: changed
         run: |
-          if [ -f .commit-sha ]; then
-            PREVIOUS_SHA=$(cat .commit-sha)
-            if [ "$PREVIOUS_SHA" != "${{ steps.current.outputs.sha }}" ]; then
-              echo "changed=true" >> $GITHUB_OUTPUT
-            else
-              echo "changed=false" >> $GITHUB_OUTPUT
-            fi
-          else
-            echo "changed=true" >> $GITHUB_OUTPUT
-          fi
+          ( [ ! -f Casks/super.rb ] || [ $(awk '/version/ {print $2}' Casks/super.rb | head -1 | tr -d '"') != $(git -C super rev-parse --short HEAD | cut -c1-7) ] ) && echo "changed=true" >> $GITHUB_OUTPUT || true
       - uses: actions/setup-go@v5
         with:
           go-version-file: super/go.mod
@@ -66,8 +41,7 @@ jobs:
       - name: Upload artifacts to S3 bucket
         if: steps.changed.outputs.changed == 'true'
         run: |
-          sha_hash=${{ steps.current.outputs.sha }}
-          short_hash=${sha_hash:0:9}
+          short_hash=$(git -C super rev-parse --short HEAD)
           for artifact in super/dist/super-${short_hash}*; do aws s3 cp $artifact s3://super-prereleases/${short_hash}/ ; done
       - name: Save updated Cask to Homebrew tap repo
         if: steps.changed.outputs.changed == 'true'
@@ -77,14 +51,5 @@ jobs:
           git config --global user.name 'Brim Automation'
           git config --global user.email 'automation@brimdata.com'
           git add Casks/super.rb
-          git commit -am "update super Homebrew Cask to ${{ steps.current.outputs.sha }}" || true
+          git commit -am "update super Homebrew Cask to $(git -C super rev-parse --short HEAD)" || true
           git push
-      - name: Save current commit SHA
-        if: steps.changed.outputs.changed == 'true'
-        run: echo "${{ steps.current.outputs.sha }}" > .commit-sha
-      - name: Save commit SHA cache
-        if: steps.changed.outputs.changed == 'true'
-        uses: actions/cache/save@v4
-        with:
-          path: .commit-sha
-          key: main-commit-${{ steps.current.outputs.sha }}

--- a/.github/workflows/homebrew-update.yaml
+++ b/.github/workflows/homebrew-update.yaml
@@ -1,0 +1,90 @@
+name: "Update SuperDB Homebrew Cask"
+
+on:
+  schedule:
+    - cron: '5 8 * * *'
+  workflow_dispatch:
+
+jobs:
+  build-and-update:
+    runs-on: ubuntu-22.04
+    steps:
+      - name: Checkout homebrew-tap
+        uses: actions/checkout@v4
+        with:
+          token: ${{ secrets.PAT_TOKEN }}
+          fetch-depth: 0    
+      - name: Checkout super
+        uses: actions/checkout@v4
+        with:
+          repository: brimdata/super
+          fetch-depth: 0
+          path: super
+      - name: Get current super main commit SHA
+        id: current
+        run: |
+          cd super
+          CURRENT_SHA=$(git rev-parse origin/main)
+          echo "sha=$CURRENT_SHA" >> $GITHUB_OUTPUT
+      - name: Restore previous commit SHA
+        id: cache
+        uses: actions/cache/restore@v4
+        with:
+          path: .commit-sha
+          key: main-commit-${{ steps.current.outputs.sha }}
+          restore-keys: |
+            main-commit-
+      - name: Check if super main has changed
+        id: changed
+        run: |
+          if [ -f .commit-sha ]; then
+            PREVIOUS_SHA=$(cat .commit-sha)
+            if [ "$PREVIOUS_SHA" != "${{ steps.current.outputs.sha }}" ]; then
+              echo "changed=true" >> $GITHUB_OUTPUT
+            else
+              echo "changed=false" >> $GITHUB_OUTPUT
+            fi
+          else
+            echo "changed=true" >> $GITHUB_OUTPUT
+          fi
+      - uses: actions/setup-go@v5
+        with:
+          go-version-file: super/go.mod
+          cache-dependency-path: super/go.sum
+      - name: Build new artifacts if super changed since last run
+        if: steps.changed.outputs.changed == 'true'
+        uses: goreleaser/goreleaser-action@v6
+        with:
+          workdir: super
+          args: release --config=${{ github.workspace }}/.super-prerelease-cask-goreleaser.yaml --snapshot --clean
+      - uses: aws-actions/configure-aws-credentials@v5
+        if: steps.changed.outputs.changed == 'true'
+        with:
+          aws-access-key-id: ${{ secrets.AWS_ACCESS_KEY_ID }}
+          aws-secret-access-key: ${{ secrets.AWS_SECRET_ACCESS_KEY }}
+          aws-region: us-east-2
+      - name: Upload artifacts to S3 bucket
+        if: steps.changed.outputs.changed == 'true'
+        run: |
+          sha_hash=${{ steps.current.outputs.sha }}
+          short_hash=${sha_hash:0:9}
+          for artifact in super/dist/super-${short_hash}*; do aws s3 cp $artifact s3://super-prereleases/${short_hash}/ ; done
+      - name: Save updated Cask to Homebrew tap repo
+        if: steps.changed.outputs.changed == 'true'
+        run: |
+          mkdir -p Casks
+          cp super/dist/homebrew/Casks/super.rb Casks
+          git config --global user.name 'Brim Automation'
+          git config --global user.email 'automation@brimdata.com'
+          git add Casks/super.rb
+          git commit -am "update super Homebrew Cask to ${{ steps.current.outputs.sha }}" || true
+          git push
+      - name: Save current commit SHA
+        if: steps.changed.outputs.changed == 'true'
+        run: echo "${{ steps.current.outputs.sha }}" > .commit-sha
+      - name: Save commit SHA cache
+        if: steps.changed.outputs.changed == 'true'
+        uses: actions/cache/save@v4
+        with:
+          path: .commit-sha
+          key: main-commit-${{ steps.current.outputs.sha }}

--- a/.super-prerelease-cask-goreleaser.yaml
+++ b/.super-prerelease-cask-goreleaser.yaml
@@ -1,0 +1,46 @@
+# GoReleaser v2 configuration
+version: 2
+
+project_name: super
+builds:
+  - main: ./cmd/super
+    env:
+      - CGO_ENABLED=0
+    ldflags:
+      - -s -X github.com/brimdata/super/cli.version={{ .ShortCommit }}
+    goarch:
+      - amd64
+      - arm64
+    goos:
+      - linux
+      - windows
+      - darwin
+archives:
+  - name_template: "{{ .ProjectName }}-{{ .ShortCommit }}.{{ .Os }}-{{ .Arch }}"
+    format_overrides:
+      - goos: windows
+        formats: [ "zip" ]
+    files:
+      - LICENSE.txt
+      - acknowledgments.txt
+release:
+  header: |
+    View [change log](CHANGELOG.md#{{ replace .Tag "." "" }}).
+homebrew_casks:
+  - repository:
+      owner: brimdata
+      name: homebrew-tap
+    commit_author:
+      name: brim-bot
+      email: bot@brimdata.io
+    homepage: https://github.com/brimdata/super
+    description: |
+      An analytics database that fuses structured and semi-structured data
+    url:
+      template: "https://super-prereleases.s3.us-east-2.amazonaws.com/{{ .ShortCommit }}/{{ .ArtifactName }}"
+checksum:
+  name_template: 'super-checksums.txt'
+snapshot:
+  version_template: "{{ .ShortCommit }}"
+changelog:
+  disable: true


### PR DESCRIPTION
## What's Changing

A nightly Actions job is enabled that updates a Homebrew Cask for prerelease `super` if the super repo's tip of `main` has advanced since the last Cask was created.

## Why

1. As described in https://github.com/brimdata/super/pull/6271, GoReleaser is pushing us toward using Casks rather than Formulas, so this is is a step toward where we'll want to be at GA
2. I'd been updating the prerelease Formula manually on a "best effort" basis, but the automatic/daily approach here should get us better user testing in this prerelease phase

## Details

Consensus has been that we don't want any artifacts on the [super Releases](https://github.com/brimdata/super/releases) page on GitHub until we're ready to tag a GA release. The approach here gets around that putting the artifacts on a public S3 bucket instead and having the Homebrew Cask point at those URLs.

Part of the goal here is to get prerelease users off the Formula and onto the Cask before GA. Based on my research there's no way to silently _force_ that transition, so when this merges, my next planned step will be to replace the old [`super.rb` Homebrew Formula](https://github.com/brimdata/homebrew-tap/blob/main/super.rb) with one that installs a shim that will advise users of the minimal steps to switch over to the Cask. At that point they'll start getting updated `super` binaries as part of every general `brew update` / `brew upgrade`. I'd plan to remove that `super.db` Formula entirely right before we tag the GA release.

I've tested this extensively in a [personal super fork](https://github.com/philrz/super) and [personal Homebrew tap](https://github.com/philrz/homebrew-tap) so if you want to see proof it works run `brew install philrz/tap/super` on a scratch macOS system with Homebrew installed.