### PR TITLE
Replace super Formula with a shim to encourage Cask reinstall

### DIFF
--- a/super.rb
+++ b/super.rb
@@ -1,17 +1,16 @@
 class Super < Formula
-  desc "An analytics database that fuses structured and semi-structured data"
+  desc "Deprecated - use 'brew install --cask brimdata/tap/super' instead"
   homepage "https://superdb.org"
-  url "https://github.com/brimdata/super/archive/4130d71.zip"
-  sha256 "3310943cf50523b83c9e5d0a0107f61e03c3f3462d52ab4f48e1c7b62a44cdfa"
-  version "4130d71"
-
-  depends_on "go@1.24" => :build
+  url "https://raw.githubusercontent.com/brimdata/super/refs/heads/main/LICENSE.txt"
+  sha256 "1b37b0c058da81d58ff531c34a564078588849614ee0afd48cccb99c7747ebcf"
+  version "9999999"
 
   def install
-    ENV["GOPATH"] = buildpath
-    (buildpath/"build/src").mkpath
-    ln_s buildpath, buildpath/"build/src/github.com"
-    system "GOPATH=$PWD/build go install github.com/brimdata/super/cmd/super@4130d71"
-    bin.install "build/bin/super"
+    (bin/"super").write <<~EOS
+      #!/bin/bash
+      echo "This formula has been replaced by a cask."
+      echo "Please run: brew uninstall --force super && brew install --cask brimdata/tap/super"
+      exit 1
+    EOS
   end
 end


### PR DESCRIPTION
## What's Changing

This replaces the old `super` Formula with a shim script that informs the user of the necessary command to install the Cask instead.

## Why

Despite the alleged existence of a way to automatically migrate users of a Formula to a Cask within the same tap, I've been unable to get it to work.

## Details

I posted a [comment](https://github.com/Homebrew/brew/pull/20800#issuecomment-3387271679) in the relevant Homebrew PR showing how I was unable to get migration to work. A maintainer did respond and said they'd take a closer look, but it's been a couple weeks and I've not yet seen further response. Meanwhile, `super` users that had the old Formula installed but only ever do a general `brew update` / `brew upgrade` will remain stuck on the old version and not be able to take advantage of the Cask that's updated nightly. This shim approach should more aggressively get them onto the Cask. If/when I'm able to get the migration approach working, I can replace/retire the Formula as necessary to use that instead.

## Testing

I tested this out on a personal tap by:

1. Having an old `super.rb` Formula similar to the one at current tip of `main` in this tap
2. Installing that old Formula onto a scratch host
3. Replacing the `super.rb` Formula in the tap with a shim like the one in this branch
4. Doing a `brew update` / `brew upgrade` on the scratch host

Output on the scratch host picking up right before step 4:

```
$ super -version
Version: v0.0.0-20250819180341-4130d7106717

$ brew update
==> Updating Homebrew...
Installing from the API is now the default behaviour!
You can save space and time by running:
  brew untap homebrew/core
  brew untap homebrew/cask
Updated 1 tap (philrz/tap).
==> Outdated Formulae
super

You have 1 outdated formula installed.
You can upgrade it with brew upgrade
or list it with brew outdated.

$ brew upgrade
==> Upgrading 1 outdated package:
philrz/tap/super 4130d71 -> 9999999
==> Fetching downloads for: super
==> Fetching philrz/tap/super
==> Downloading https://raw.githubusercontent.com/brimdata/super/refs/heads/main/LICENSE.txt
####################################################################################################### 100.0%
==> Upgrading philrz/tap/super
  4130d71 -> 9999999 
🍺  /opt/homebrew/Cellar/super/9999999: 5 files, 5.2KB, built in 1 second

$ super -version
This formula has been replaced by a cask.
Please run: brew uninstall --force super && brew install --cask philrz/tap/super

$ brew uninstall --force super && brew install --cask philrz/tap/super
Warning: Treating super as a formula. For the cask, use philrz/tap/super or specify the `--cask` flag. To silence this message, use the `--formula` flag.
Uninstalling super... (12 files, 65.7MB)
==> Autoremoving 1 unneeded formula:
go@1.24
Uninstalling /opt/homebrew/Cellar/go@1.24/1.24.9... (14,123 files, 244.1MB)
==> Downloading https://super-prereleases.s3.us-east-2.amazonaws.com/3765cc2/super-3765cc2.darwin-arm64.tar.gz
...
```
